### PR TITLE
fix(git): filter out empty lines in git status output

### DIFF
--- a/electron/gitUtils.ts
+++ b/electron/gitUtils.ts
@@ -122,7 +122,10 @@ export async function getGitStatus(directoryPath: string): Promise<GitFileStatus
     DEBUG(`git status --porcelain=v1 output:\n${output}`);
 
     const files: GitFileStatus[] = [];
-    const lines = output.split('\n');
+    // Split output by newline and filter out any empty strings.
+    // This prevents processing a blank line which can occur if the git command's
+    // output has a trailing newline.
+    const lines = output.split('\n').filter(Boolean);
 
     for (const line of lines) {
       DEBUG(`Raw line: "${line}"`);


### PR DESCRIPTION
Prevent processing of blank lines caused by trailing newlines in the
git status output. This change splits the output by newline and filters
out empty strings to avoid unnecessary parsing of empty lines.

Closes #2