### PR TITLE
feat(electron): resolve user shell environment for command execution

### DIFF
--- a/electron/gitUtils.ts
+++ b/electron/gitUtils.ts
@@ -2,6 +2,7 @@
 import { exec } from 'node:child_process';
 import path from 'node:path';
 import { getErrorMessage, toPosixPath } from './utils';
+import { getShellEnv } from './sync';
 import type { GitFileStatus } from '@shared/electron-api';
 
 const VERBOSE_LOGGING = false;
@@ -22,7 +23,8 @@ async function runGitCommand(cwd: string, command: string, trim = true): Promise
   return new Promise((resolve, reject) => {
     // Ensure commands are executed with git prefix
     const fullCommand = command.startsWith('git ') ? command : `git ${command}`;
-    exec(fullCommand, { cwd }, (error, stdout, stderr) => {
+    const shellEnv = getShellEnv();
+    exec(fullCommand, { cwd, env: shellEnv }, (error, stdout, stderr) => {
       if (error) {
         const errorMessage = (trim ? stderr.trim() : stderr) || error.message;
         return reject(new Error(`Git command "${command}" failed: ${errorMessage}`));
@@ -36,7 +38,8 @@ async function runGitCommand(cwd: string, command: string, trim = true): Promise
 async function runGitCommandWithExitCode(cwd: string, command: string, trim = true): Promise<GitCommandResult> {
   return new Promise((resolve) => {
     const fullCommand = command.startsWith('git ') ? command : `git ${command}`;
-    exec(fullCommand, { cwd }, (error, stdout, stderr) => {
+    const shellEnv = getShellEnv();
+    exec(fullCommand, { cwd, env: shellEnv }, (error, stdout, stderr) => {
       resolve({
         stdout: trim ? stdout.trim() : stdout,
         stderr: trim ? stderr.trim() : stderr,

--- a/electron/ipcHandlers/executionApi.ts
+++ b/electron/ipcHandlers/executionApi.ts
@@ -2,7 +2,7 @@
 import { ipcMain } from 'electron';
 import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process';
 import { getErrorMessage } from '../utils';
-import { getCurrentRootPath } from '../sync';
+import { getCurrentRootPath, getShellEnv } from '../sync';
 import { TerminalOutputEvent, TerminalCommandExitEvent } from '@shared/electron-api';
 import { getWindowFromEvent } from './ipcUtils';
 
@@ -23,10 +23,12 @@ export function registerExecutionApiHandlers(): void {
     }
 
     try {
+      const shellEnv = getShellEnv();
       const child: ChildProcessWithoutNullStreams = spawn(commandToRun, [], {
         cwd: rootPath,
         shell: true,
         detached: false,
+        env: shellEnv,
       });
 
       child.stdout.on('data', (data: Buffer) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,9 +5,9 @@ import { VITE_DEV_SERVER_URL, APP_TITLE } from './config';
 import { createWindow, setupAppEventHandlers } from './windowManager';
 import { registerIpcHandlers } from './ipcHandlers';
 import { waitForVite } from './devUtils';
-import { getErrorMessage } from './utils';
+import { getErrorMessage, getShellEnvironment } from './utils';
 import * as settingsManager from './settingsManager';
-import { onNewRootPath, signalMainProcessReady } from './sync';
+import { onNewRootPath, signalMainProcessReady, setShellEnv } from './sync';
 
 console.log('Electron main.ts starting...');
 console.log('VITE_DEV_SERVER_URL from config:', VITE_DEV_SERVER_URL);
@@ -33,6 +33,16 @@ async function initializeApp() {
   }
 
   await app.whenReady();
+
+  try {
+    const shellEnv = await getShellEnvironment();
+    setShellEnv(shellEnv);
+    console.log('[Main] Resolved and cached user shell environment.');
+  } catch (e) {
+    const errorMsg = getErrorMessage(e);
+    console.error(`[Main] Could not resolve shell environment: ${errorMsg}. Falling back to process.env.`);
+    setShellEnv(process.env);
+  }
 
   registerIpcHandlers();
   console.log('[Main] registerIpcHandlers() called.');

--- a/electron/sync.ts
+++ b/electron/sync.ts
@@ -8,6 +8,16 @@ import { setupAppMenu } from './appMenu';
 let isMainProcessReady = false;
 let readyResolvers: Array<() => void> = [];
 let currentRootPath: string | null = null;
+let cachedShellEnv: NodeJS.ProcessEnv = {};
+
+export function getShellEnv(): NodeJS.ProcessEnv {
+  return cachedShellEnv;
+}
+
+export function setShellEnv(env: NodeJS.ProcessEnv): void {
+  console.log('[Sync] Caching resolved shell environment.');
+  cachedShellEnv = env;
+}
 
 export function signalMainProcessReady(): void {
   if (isMainProcessReady) return;

--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -2,6 +2,7 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
+import { exec } from 'node:child_process';
 import { isPathIgnoredByGit, shouldRespectGitignoreRules } from './gitignoreManager';
 import { MAX_FILE_SIZE_BYTES } from './config';
 import type { FsEntry } from '@shared/electron-api';
@@ -237,4 +238,65 @@ export async function readFileWithChecks(
     console.error(`[readFileWithChecks] Error reading file ${relativeFilePath}: ${getErrorMessage(error)}`);
     return { error: getErrorMessage(error) };
   }
+}
+
+/**
+ * Resolves the user's shell environment by spawning a login shell and capturing its environment variables.
+ * This is crucial for finding user-installed tools (like npm, git from homebrew) when the app is
+ * launched from a GUI.
+ * @returns A promise that resolves to the shell's environment variables.
+ */
+export async function getShellEnvironment(): Promise<NodeJS.ProcessEnv> {
+  if (process.platform === 'win32') {
+    // On Windows, the PATH is usually inherited correctly. A more complex solution might be needed
+    // for shells like Git Bash, but for now, this is sufficient.
+    return process.env;
+  }
+
+  return new Promise((resolve) => {
+    const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+    // The command must be structured to work with `sh` which is what `exec` may use.
+    // The `-ilc` flags ensure an interactive, login shell is simulated to source profiles.
+    const command = `'${shell}' -ilc 'echo "___SHELL_ENV_START___" && env && echo "___SHELL_ENV_END___"'`;
+
+    exec(command, { shell: '/bin/sh' }, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`[getShellEnvironment] Error executing command to get shell env: ${error.message}`);
+        console.warn(`[getShellEnvironment] Stderr: ${stderr}`);
+        // Fallback to the current, possibly minimal, environment
+        return resolve(process.env);
+      }
+
+      const startMarker = '___SHELL_ENV_START___';
+      const endMarker = '___SHELL_ENV_END___';
+      const startIndex = stdout.indexOf(startMarker);
+      const endIndex = stdout.lastIndexOf(endMarker);
+
+      if (startIndex === -1 || endIndex === -1) {
+        console.error(
+          `[getShellEnvironment] Shell environment markers not found in stdout. Output: ${stdout.substring(0, 500)}`
+        );
+        return resolve(process.env);
+      }
+
+      const envBlock = stdout.substring(startIndex + startMarker.length, endIndex);
+      const env: NodeJS.ProcessEnv = {};
+
+      for (const line of envBlock.split('\n')) {
+        const trimmedLine = line.trim();
+        if (trimmedLine) {
+          const parts = trimmedLine.split('=', 2); // Split only on the first '='
+          if (parts.length === 2 && parts[0]) {
+            env[parts[0]] = parts[1];
+          }
+        }
+      }
+
+      // Merge with current process.env, giving the resolved shell env precedence.
+      // This preserves any environment variables set specifically for the Electron app
+      // while overriding common ones like PATH with the user's full configuration.
+      const mergedEnv = { ...process.env, ...env };
+      resolve(mergedEnv);
+    });
+  });
 }


### PR DESCRIPTION
Implemented a robust mechanism to resolve the user's full login shell environment on application startup. This captures the complete 'PATH' and other essential environment variables, ensuring that command-line tools like 'npm', 'npx', or those installed via Homebrew are found and executed correctly from within the packaged application.

- Added a 'getShellEnvironment' utility in 'electron/utils.ts' that spawns the user's default login shell ('zsh' or 'bash') to capture its environment.
- The resolved environment is cached globally at startup in 'electron/sync.ts’.
- The 'executionApi' now injects this cached environment into all 'spawn' calls for terminal commands.

This fixes a critical bug where commands would fail with "command not found" errors when the app was run from the GUI on macOS and Linux, as it previously operated with a minimal, non-login shell environment.

Also applied the environment fix to the internal 'gitUtils.ts' module. The 'runGitCommand' and 'runGitCommandWithExitCode' helpers now inject the cached user shell environment into their 'child_process.exec' calls as well. This ensures that the Git integration can reliably find and execute the 'git' binary, even when it's installed in a non-standard location via tools like Homebrew.